### PR TITLE
fix: Optionally convert process parameters.

### DIFF
--- a/index.js
+++ b/index.js
@@ -152,7 +152,7 @@ class Dictionary {
     if (isWithProcess) {
       processesList = tabToConvert.getProcessesList()
         .map(procesItem => {
-          return this.convertProcess(procesItem);
+          return this.convertProcess(procesItem, false);
         });
     }
 
@@ -481,7 +481,7 @@ class Dictionary {
       });
   }
 
-  convertProcess(processToConvert) {
+  convertProcess(processToConvert, isConvertedFields = true) {
     if (processToConvert === undefined || processToConvert === null) {
       return undefined;
     }
@@ -490,11 +490,14 @@ class Dictionary {
       processId: processToConvert.getId(),
     };
 
-    //  Convert from gRPC
-    const parametersList = processToConvert.getParametersList()
-      .map(fieldItem => {
-        return this.convertField(fieldItem, additionalAttributes);
-      });
+    //  Convert fiels list from gRPC
+    let parametersList;
+    if (isConvertedFields) {
+      parametersList = processToConvert.getParametersList()
+        .map(fieldItem => {
+          return this.convertField(fieldItem, additionalAttributes);
+        });
+    }
 
     //  Get export list
     const reportExportTypeList = processToConvert.getReportexporttypesList()
@@ -581,7 +584,8 @@ class Dictionary {
         browserToConvert.getWindow(), true
       ),
       process: this.convertProcess(
-        browserToConvert.getProcess()
+        browserToConvert.getProcess(),
+        false
       ),
       //
       fieldsList: fieldsList

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adempiere/grpc-dictionary-client",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "ADempiere Dictionary Client write in Javascript for gRPC service",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Optionally convert process parameters, apply to tabs and smart browser, since the metadata of the associated processes do not include the metadata of the parameters.